### PR TITLE
fix(side menu): fix first-level menu styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add switch component example
 * Fix table header example 
 * Fix #84: Apply new colors, font-sizes and separations to titles
+* Fix #82: Use the same blue marker to show active item on sidebar menu
 
 ## 1.3.0 (Abril 4, 2017)
 

--- a/src/app/layout/menu-item/menu-item.component.scss
+++ b/src/app/layout/menu-item/menu-item.component.scss
@@ -24,8 +24,16 @@
 }
 
 .item-active {
-   background-color: egeo-get-color(n1);
-   color: egeo-get-color(n10);
+   &:before {
+      content: ' ';
+      border-left: 3px egeo-get-color(a1) solid;
+      display: inline-block;
+      height: 16px;
+      margin-left: -5px;
+      margin-top: 12px;
+      padding-left: 5px;
+      vertical-align: top;
+   }
 }
 
 .first-level {
@@ -56,7 +64,9 @@
 
    .menu-item__label {
       border-color: egeo-get-color(n3);
+      display: inline-block;
       padding: 10px 0 12px 2px;
+      width: calc(100% - 10px);
    }
 }
 


### PR DESCRIPTION
use the same blue marker to show what menu is active in all levels depth

Close #82

## TYPE
- Bugfix

## Description
use the same blue marker to show what menu is active in all levels depth

### Documentation
- [x] Have changelog.md updated

### Code
- [x] Have 3 spaces indentation

### Other observations
-

### Post-review reminder
- Remember reviewer approve changes inside the Files Changed tab (Review changes dropdown)
- Squash commits
- Release version in case of breaking changes and notify of all front
