### PR TITLE
feat(st-toggle-buttons): Add an optional id to the interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Update radio menu component documentation
 * Create help component documentation
 * Create tip component documentation
+* Add an optional id to the st-toggle-button interface
 
 
 ## 1.3.0 (Abril 4, 2017)

--- a/src/app/+components/toggle-button/example-code/toggle-button.model.ts.txt
+++ b/src/app/+components/toggle-button/example-code/toggle-button.model.ts.txt
@@ -1,5 +1,6 @@
 export interface StToggleButton {
    label: string;
+   id?: string;
    number?: number;
    active?: boolean;
 }


### PR DESCRIPTION
## TYPE
- Improvement

## Description
 Add an optional id to the interface of st-toggle-button

### Documentation
- [x] Have changelog.md updated

### Code
- [x] Have 3 spaces indentation

### Other observations

### Post-review reminder
- Remember reviewer approve changes inside the Files Changed tab (Review changes dropdown)
- Squash commits
- Release version in case of breaking changes and notify of all front
